### PR TITLE
fixes a race when logging out

### DIFF
--- a/src/app/header-bar/header-bar.component.ts
+++ b/src/app/header-bar/header-bar.component.ts
@@ -67,8 +67,9 @@ export class HeaderBarComponent implements OnInit {
   }
 
   logout() {
-    this.authService.logout();
-    window.location.reload();
+    this.authService.logout().subscribe(() => {
+      window.location.reload();
+    });
   }
 
   searchCharts(input: HTMLInputElement): void {

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -45,8 +45,8 @@ export class AuthService {
   /**
    * Logs user out
    */
-  logout() {
+  logout(): Observable<Response> {
     this.cookieService.remove('ka_claims');
-    this.http.delete(`${this.hostname}/auth/logout`, {withCredentials: true}).subscribe();
+    return this.http.delete(`${this.hostname}/auth/logout`, {withCredentials: true});
   }
 }


### PR DESCRIPTION
If the logout request does not complete in time, the browser does not
update the cookie as expired. We now wait for the logout request to
succeed before reloading

see kubeapps/hub#16