### PR TITLE
selectable chart versions

### DIFF
--- a/src/components/ChartView/ChartDeployButton.tsx
+++ b/src/components/ChartView/ChartDeployButton.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import * as Modal from "react-modal";
 import { RouterAction } from "react-router-redux";
-import { IChart } from "../../shared/types";
+import { IChartVersion } from "../../shared/types";
 
 interface IChartDeployButtonProps {
-  chart: IChart;
-  deployChart: (chart: IChart, releaseName: string, namespace: string) => Promise<{}>;
+  version: IChartVersion;
+  deployChart: (chartVersion: IChartVersion, releaseName: string, namespace: string) => Promise<{}>;
   push: (location: string) => RouterAction;
 }
 
@@ -92,10 +92,10 @@ class ChartDeployButton extends React.Component<IChartDeployButtonProps, IChartD
 
   public handleDeploy = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { chart, deployChart, push } = this.props;
+    const { version, deployChart, push } = this.props;
     this.setState({ isDeploying: true });
     const { releaseName, namespace } = this.state;
-    deployChart(chart, releaseName, namespace)
+    deployChart(version, releaseName, namespace)
       .then(() => push(`/apps/${releaseName}`))
       .catch(err => this.setState({ isDeploying: false, error: err.toString() }));
   };

--- a/src/components/ChartView/ChartVersionsList.tsx
+++ b/src/components/ChartView/ChartVersionsList.tsx
@@ -1,22 +1,47 @@
 import * as React from "react";
+import { Link } from "react-router-dom";
 
 import { IChartVersion } from "../../shared/types";
+import * as url from "../../shared/url";
 
 interface IChartVersionsListProps {
+  selected: IChartVersion;
   versions: IChartVersion[];
 }
 
-class ChartVersionsList extends React.Component<IChartVersionsListProps> {
+interface IChartVersionsListState {
+  showAll: boolean;
+}
+
+class ChartVersionsList extends React.Component<IChartVersionsListProps, IChartVersionsListState> {
+  public state: IChartVersionsListState = {
+    showAll: false,
+  };
+
   public render() {
-    const items = this.props.versions.slice(0, 5).map(v => (
-      <li key={v.id}>
-        {v.attributes.version} - {this.formatDate(v.attributes.created)}
-      </li>
-    ));
+    const versions = this.state.showAll ? this.props.versions : this.props.versions.slice(0, 5);
+    const items = versions.map(v => {
+      const selectedClass =
+        this.props.selected.attributes.version === v.attributes.version
+          ? "type-bold type-color-action"
+          : "";
+      return (
+        <li key={v.id}>
+          <Link className={selectedClass} to={url.app.charts.version(v)}>
+            {v.attributes.version} - {this.formatDate(v.attributes.created)}
+          </Link>
+        </li>
+      );
+    });
     return (
       <div className="ChartVersionsList">
         <ul className="remove-style padding-l-reset margin-b-reset">{items}</ul>
-        <span className="type-small">Show all...</span>
+        {!this.state.showAll &&
+          this.props.versions.length > 5 && (
+            <span className="type-small" onClick={this.handleShowAll}>
+              Show all...
+            </span>
+          )}
       </div>
     );
   }
@@ -25,6 +50,12 @@ class ChartVersionsList extends React.Component<IChartVersionsListProps> {
     const d = new Date(dateStr);
     return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
   }
+
+  public handleShowAll = () => {
+    this.setState({
+      showAll: true,
+    });
+  };
 }
 
 export default ChartVersionsList;

--- a/src/components/ChartView/ChartVersionsList.tsx
+++ b/src/components/ChartView/ChartVersionsList.tsx
@@ -38,9 +38,9 @@ class ChartVersionsList extends React.Component<IChartVersionsListProps, IChartV
         <ul className="remove-style padding-l-reset margin-b-reset">{items}</ul>
         {!this.state.showAll &&
           this.props.versions.length > 5 && (
-            <span className="type-small" onClick={this.handleShowAll}>
+            <a className="type-small" onClick={this.handleShowAll}>
               Show all...
-            </span>
+            </a>
           )}
       </div>
     );

--- a/src/containers/ChartViewContainer/ChartViewContainer.tsx
+++ b/src/containers/ChartViewContainer/ChartViewContainer.tsx
@@ -4,13 +4,14 @@ import { Dispatch } from "redux";
 import { push } from "react-router-redux";
 import actions from "../../actions";
 import ChartView from "../../components/ChartView";
-import { IChart, IStoreState } from "../../shared/types";
+import { IChartVersion, IStoreState } from "../../shared/types";
 
 interface IRouteProps {
   match: {
     params: {
       repo: string;
       id: string;
+      version?: string;
     };
   };
 }
@@ -20,15 +21,19 @@ function mapStateToProps({ charts }: IStoreState, { match: { params } }: IRouteP
     chartID: `${params.repo}/${params.id}`,
     isFetching: charts.isFetching,
     selected: charts.selected,
+    version: params.version,
   };
 }
 
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
-    deployChart: (chart: IChart, releaseName: string, namespace: string) =>
-      dispatch(actions.charts.deployChart(chart, releaseName, namespace)),
-    getChart: (id: string) => dispatch(actions.charts.getChart(id)),
+    deployChart: (version: IChartVersion, releaseName: string, namespace: string) =>
+      dispatch(actions.charts.deployChart(version, releaseName, namespace)),
+    fetchChartVersionsAndSelectVersion: (id: string, version?: string) =>
+      dispatch(actions.charts.fetchChartVersionsAndSelectVersion(id, version)),
     push: (location: string) => dispatch(push(location)),
+    selectChartVersionAndGetReadme: (version: IChartVersion) =>
+      dispatch(actions.charts.selectChartVersionAndGetReadme(version)),
   };
 }
 

--- a/src/containers/Root.tsx
+++ b/src/containers/Root.tsx
@@ -24,6 +24,11 @@ class Root extends React.Component {
               <Route exact={true} path="/charts" component={ChartList} />
               <Route exact={true} path="/charts/:repo" component={ChartList} />
               <Route exact={true} path="/charts/:repo/:id" component={ChartView} />
+              <Route
+                exact={true}
+                path="/charts/:repo/:id/versions/:version"
+                component={ChartView}
+              />
             </section>
           </Layout>
         </ConnectedRouter>

--- a/src/reducers/charts.ts
+++ b/src/reducers/charts.ts
@@ -17,8 +17,8 @@ const chartsSelectedReducer = (
   action: ChartsAction,
 ): IChartState["selected"] => {
   switch (action.type) {
-    case getType(actions.charts.selectChart):
-      return { ...state, chart: action.chart };
+    case getType(actions.charts.selectChartVersion):
+      return { ...state, version: action.chartVersion };
     case getType(actions.charts.receiveChartVersions):
       return {
         ...state,
@@ -40,9 +40,10 @@ const chartsReducer = (state: IChartState = initialState, action: ChartsAction):
     case getType(actions.charts.receiveChartVersions):
       return {
         ...state,
+        isFetching: false,
         selected: chartsSelectedReducer(state.selected, action),
       };
-    case getType(actions.charts.selectChart):
+    case getType(actions.charts.selectChartVersion):
       return {
         ...state,
         isFetching: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -44,7 +44,7 @@ export interface IChartAttributes {
 export interface IChartState {
   isFetching: boolean;
   selected: {
-    chart?: IChart;
+    version?: IChartVersion;
     versions: IChartVersion[];
     readme?: string;
   };

--- a/src/shared/url.ts
+++ b/src/shared/url.ts
@@ -1,3 +1,14 @@
+import { IChartVersion } from "./types";
+
+export const app = {
+  charts: {
+    version: (cv: IChartVersion) =>
+      `/charts/${cv.relationships.chart.data.repo.name}/${
+        cv.relationships.chart.data.name
+      }/versions/${cv.attributes.version}`,
+  },
+};
+
 export const api = {
   charts: {
     base: "/api/chartsvc/v1",


### PR DESCRIPTION
- select chart versions from chart versions list
- adds route /chart/:repo/:chart/versions/:version to drill down on
  version details
- chartview is rendered based on the selected chart version type (latest by
  default) instead of the chart type

fixes #35