### PR TITLE
split tslint rules for dev and ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "build": "react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject",
-    "tslint-check": "tslint-config-prettier-check ./tslint.json",
+    "tslint-check": "tslint-config-prettier-check ./tslint.ci.json",
     "precommit": "lint-staged",
     "prettier": "prettier --write 'src/**/*.{ts,tsx,css}'",
-    "lint": "tslint 'src/**/*.{ts,tsx}'",
-    "lint-fix": "tslint --fix 'src/**/*.{ts,tsx}'"
+    "lint": "tslint -c ./tslint.ci.json 'src/**/*.{ts,tsx}'",
+    "lint-fix": "tslint -c ./tslint.ci.json --fix 'src/**/*.{ts,tsx}'"
   },
   "lint-staged": {
-    "*.{ts,tsx}": ["tslint --fix", "prettier --write", "git add"],
+    "*.{ts,tsx}": ["tslint -c ./tslint.ci.json --fix", "prettier --write", "git add"],
     "*.{js,json,css,md}": ["prettier --write", "git add"]
   },
   "devDependencies": {

--- a/tslint.ci.json
+++ b/tslint.ci.json
@@ -2,10 +2,6 @@
   "defaultSeverity": "error",
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "jsRules": {},
-  "rules": {
-    "no-console": {
-      "severity": "warning"
-    }
-  },
+  "rules": {},
   "rulesDirectory": []
 }


### PR DESCRIPTION
In development, console.log's are useful for debugging. This updates the
main tslint.json file to not error when console.log's are present, but
to just emit warnings. Since tslint doesn't have a stricter mode where
it fails on warnings also, I've created another tslint.ci.json file that
will emit errors if console.log's are present. This file will be used in
the CI and pre-commit hooks so when a developer is ready to commit a
change they will need to remove their debug statements.