### PR TITLE
AppRepo resync button

### DIFF
--- a/src/actions/repos.ts
+++ b/src/actions/repos.ts
@@ -57,6 +57,20 @@ export const deleteRepo = (name: string, namespace: string = "kubeapps") => {
   };
 };
 
+export const resyncRepo = (name: string, namespace: string = "kubeapps") => {
+  return async (dispatch: Dispatch<IStoreState>) => {
+    const repo = await AppRepository.get(name, namespace);
+    repo.spec.resyncRequests = repo.spec.resyncRequests || 0;
+    repo.spec.resyncRequests++;
+    await AppRepository.update(name, namespace, repo);
+    // TODO: Do something to show progress
+    dispatch(requestRepos());
+    const repos = await AppRepository.list();
+    dispatch(receiveRepos(repos.items));
+    return repos;
+  };
+};
+
 export const fetchRepos = () => {
   return async (dispatch: Dispatch<IStoreState>) => {
     dispatch(requestRepos());

--- a/src/components/AppRepoList/index.tsx
+++ b/src/components/AppRepoList/index.tsx
@@ -7,6 +7,7 @@ export interface IAppRepoListProps {
   repos: IAppRepository[];
   fetchRepos: () => Promise<any>;
   deleteRepo: (name: string) => Promise<any>;
+  resyncRepo: (name: string) => Promise<any>;
   install: (name: string, url: string) => Promise<any>;
 }
 
@@ -41,6 +42,12 @@ export class AppRepoList extends React.Component<IAppRepoListProps> {
                     >
                       Delete
                     </button>
+                    <button
+                      className="button button-secondary"
+                      onClick={this.handleResyncClick(repo.metadata.name)}
+                    >
+                      Refresh
+                    </button>
                   </td>
                 </tr>
               );
@@ -53,4 +60,5 @@ export class AppRepoList extends React.Component<IAppRepoListProps> {
   }
 
   private handleDeleteClick = (repoName: string) => () => this.props.deleteRepo(repoName);
+  private handleResyncClick = (repoName: string) => () => this.props.resyncRepo(repoName);
 }

--- a/src/containers/RepoListContainer.ts
+++ b/src/containers/RepoListContainer.ts
@@ -22,6 +22,9 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
     install: async (name: string, url: string, namespace: string = "kubeapps") => {
       return dispatch(actions.repos.installRepo(name, url, namespace));
     },
+    resyncRepo: async (name: string, namespace: string = "kubeapps") => {
+      return dispatch(actions.repos.resyncRepo(name, namespace));
+    },
   };
 }
 

--- a/src/shared/AppRepository.ts
+++ b/src/shared/AppRepository.ts
@@ -10,6 +10,16 @@ export class AppRepository {
     return data;
   }
 
+  public static async get(name: string, namespace: string = "default") {
+    const { data } = await axios.get(AppRepository.getSelfLink(name, namespace));
+    return data;
+  }
+
+  public static async update(name: string, namespace: string = "default", newApp: IAppRepository) {
+    const { data } = await axios.put(AppRepository.getSelfLink(name, namespace), newApp);
+    return data;
+  }
+
   public static async delete(name: string, namespace: string = "default") {
     const { data } = await axios.delete(AppRepository.getSelfLink(name, namespace));
     return data;


### PR DESCRIPTION
Ref: #47
This PR adds a "Refresh" button to resynchronize the AppRepository:

<img width="1054" alt="screen shot 2018-02-12 at 10 35 13" src="https://user-images.githubusercontent.com/4025665/36090446-b1489668-0fe0-11e8-994b-576bb0896f12.png">

It requires the changes in https://github.com/kubeapps/apprepository-controller/pull/5/ to work.

We still need a way to show some progress when the user clicks in the button `Refresh`. Right now it seems that it is not doing anything (but it is actually updating the AppRepository object)