### PR TITLE
Add bindings to create new app view

### DIFF
--- a/src/components/AppNew/AppNew.tsx
+++ b/src/components/AppNew/AppNew.tsx
@@ -152,6 +152,10 @@ class AppNew extends React.Component<IAppNewProps, IAppNewState> {
                   <p>[Optional] Select a service binding for your new app</p>
                   <label htmlFor="bindings">Bindings</label>
                   <select onChange={this.onBindingChange}>
+                    <option key="none" value="none">
+                      {" "}
+                      -- Select one --
+                    </option>
                     {bindings.map(b => (
                       <option
                         key={b.metadata.name}

--- a/src/components/AppNew/AppNew.tsx
+++ b/src/components/AppNew/AppNew.tsx
@@ -1,12 +1,15 @@
 import * as React from "react";
 import AceEditor from "react-ace";
 import { RouterAction } from "react-router-redux";
+
+import { IServiceBinding } from "../../shared/ServiceBinding";
 import { IChartState, IChartVersion } from "../../shared/types";
 
 import "brace/mode/yaml";
 import "brace/theme/xcode";
 
 interface IAppNewProps {
+  bindings: IServiceBinding[];
   chartID: string;
   deployChart: (
     version: IChartVersion,
@@ -17,6 +20,7 @@ interface IAppNewProps {
   selected: IChartState["selected"];
   chartVersion: string;
   push: (location: string) => RouterAction;
+  getBindings: () => Promise<IServiceBinding[]>;
   getChartVersion: (id: string, chartVersion: string) => Promise<{}>;
   getChartValues: (id: string, chartVersion: string) => Promise<{}>;
 }
@@ -29,6 +33,7 @@ interface IAppNewState {
   appValues?: string;
   valuesModified: boolean;
   error?: string;
+  selectedBinding: IServiceBinding | undefined;
 }
 
 class AppNew extends React.Component<IAppNewProps, IAppNewState> {
@@ -38,10 +43,12 @@ class AppNew extends React.Component<IAppNewProps, IAppNewState> {
     isDeploying: false,
     namespace: "default",
     releaseName: "",
+    selectedBinding: undefined,
     valuesModified: false,
   };
   public componentDidMount() {
-    const { chartID, getChartVersion, getChartValues, chartVersion } = this.props;
+    const { chartID, getBindings, getChartVersion, getChartValues, chartVersion } = this.props;
+    getBindings();
     getChartVersion(chartID, chartVersion);
     getChartValues(chartID, chartVersion);
   }
@@ -57,50 +64,122 @@ class AppNew extends React.Component<IAppNewProps, IAppNewState> {
     if (!this.props.selected.version && !this.state.appValues) {
       return <div>Loading</div>;
     }
+    const { bindings } = this.props;
+    const { selectedBinding } = this.state;
+    let bindingDetail = <div />;
+    if (selectedBinding) {
+      const {
+        instanceRef,
+        secretName,
+        secretDatabase,
+        secretHost,
+        secretPassword,
+        secretPort,
+        secretUsername,
+      } = selectedBinding.spec;
+
+      const statuses: Array<[string, string | undefined]> = [
+        ["Instance", instanceRef.name],
+        ["Secret", secretName],
+        ["Database", secretDatabase],
+        ["Host", secretHost],
+        ["Password", secretPassword],
+        ["Port", secretPort],
+        ["Username", secretUsername],
+      ];
+
+      bindingDetail = (
+        <dl className="container margin-normal">
+          {statuses.map(statusPair => {
+            const [key, value] = statusPair;
+            return [
+              <dt key={key}>{key}</dt>,
+              <dd key={value}>
+                <code>{value}</code>
+              </dd>,
+            ];
+          })}
+        </dl>
+      );
+    }
+
     return (
       <div>
         {this.state.error && (
           <div className="container padding-v-bigger bg-action">{this.state.error}</div>
         )}
-        <form onSubmit={this.handleDeploy}>
-          <div>
-            <label htmlFor="releaseName">Name</label>
-            <input
-              id="releaseName"
-              onChange={this.handleReleaseNameChange}
-              value={this.state.releaseName}
-              required={true}
-            />
-          </div>
-          <div>
-            <label htmlFor="namespace">Namespace</label>
-            <input
-              name="namespace"
-              onChange={this.handleNamespaceChange}
-              value={this.state.namespace}
-            />
-          </div>
-          <div style={{ marginBottom: "1em" }}>
-            <label htmlFor="values">Values (YAML)</label>
-            <AceEditor
-              mode="yaml"
-              theme="xcode"
-              name="values"
-              width="100%"
-              onChange={this.handleValuesChange}
-              setOptions={{ showPrintMargin: false }}
-              value={this.state.appValues}
-            />
-          </div>
-          <div>
-            <button className="button button-primary" type="submit">
-              Submit
-            </button>
+        <form className="container" onSubmit={this.handleDeploy}>
+          <div className="row">
+            <div className="col-8">
+              <div>
+                <label htmlFor="releaseName">Name</label>
+                <input
+                  id="releaseName"
+                  onChange={this.handleReleaseNameChange}
+                  value={this.state.releaseName}
+                  required={true}
+                />
+              </div>
+              <div>
+                <label htmlFor="namespace">Namespace</label>
+                <input
+                  name="namespace"
+                  onChange={this.handleNamespaceChange}
+                  value={this.state.namespace}
+                />
+              </div>
+              <div style={{ marginBottom: "1em" }}>
+                <label htmlFor="values">Values (YAML)</label>
+                <AceEditor
+                  mode="yaml"
+                  theme="xcode"
+                  name="values"
+                  width="100%"
+                  onChange={this.handleValuesChange}
+                  setOptions={{ showPrintMargin: false }}
+                  value={this.state.appValues}
+                />
+              </div>
+              <div>
+                <button className="button button-primary" type="submit">
+                  Submit
+                </button>
+              </div>
+            </div>
+            <div className="col-4">
+              {bindings.length > 0 && (
+                <div>
+                  <p>[Optional] Select a service binding for your new app</p>
+                  <label htmlFor="bindings">Bindings</label>
+                  <select onChange={this.onBindingChange}>
+                    {bindings.map(b => (
+                      <option
+                        key={b.metadata.name}
+                        selected={
+                          b.metadata.name === (selectedBinding && selectedBinding.metadata.name)
+                        }
+                        value={b.metadata.name}
+                      >
+                        {b.metadata.name}
+                      </option>
+                    ))}
+                  </select>
+                  {bindingDetail}
+                </div>
+              )}
+            </div>
           </div>
         </form>
       </div>
     );
   }
+
+  public onBindingChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    this.setState({
+      selectedBinding:
+        this.props.bindings.find(binding => binding.metadata.name === e.target.value) || undefined,
+    });
+  };
 
   public handleDeploy = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/ProvisionButton/index.tsx
+++ b/src/components/ProvisionButton/index.tsx
@@ -48,6 +48,7 @@ class ProvisionButton extends React.Component<IProvisionButtonProps, IProvisionB
         firewallStartIPAddress: "0.0.0.0",
         location: "eastus",
         resourceGroup: "default",
+        sslEnforcement: "disabled",
       },
       undefined,
       2,

--- a/src/containers/AppNewContainer/AppNewContainer.tsx
+++ b/src/containers/AppNewContainer/AppNewContainer.tsx
@@ -11,13 +11,17 @@ interface IRouteProps {
     params: {
       repo: string;
       id: string;
-      version?: string;
+      version: string;
     };
   };
 }
 
-function mapStateToProps({ apps, charts }: IStoreState, { match: { params } }: IRouteProps) {
+function mapStateToProps(
+  { apps, catalog, charts }: IStoreState,
+  { match: { params } }: IRouteProps,
+) {
   return {
+    bindings: catalog.bindings,
     chartID: `${params.repo}/${params.id}`,
     chartVersion: params.version,
     selected: charts.selected,
@@ -32,6 +36,7 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
       namespace: string,
       values?: string,
     ) => dispatch(actions.charts.deployChart(version, releaseName, namespace, values)),
+    getBindings: () => dispatch(actions.catalog.getBindings()),
     getChartValues: (id: string, version: string) =>
       dispatch(actions.charts.getChartValues(id, version)),
     getChartVersion: (id: string, version: string) =>


### PR DESCRIPTION
Fixes #19 

Tested against the stable/wordpress chart by updating the following in `values.yaml`:

```
externalDatabase:
## All of these values are only used when mariadb.enabled is set to false
  ## Database host
  host: <COPY FROM SELECTED BINDING>

  ## Database Root User (so wordpress can create the db schema etc)
  rootPassword: <COPY FROM SELECTED BINDING>

  ## non-root Username for Wordpress Database
  user: <COPY FROM SELECTED BINDING>

  ## Database password
  password: <COPY FROM SELECTED BINDING>

  ## Database name
  database: <COPY FROM SELECTED BINDING>

  ## Database port number
  port: 3306

...
mariadb:
  ## Whether to use the database specified as a requirement or not.
  ## If you want to use an external database set this to false and supply details to externalDatabase above
  enabled: false
```