### PR TITLE
disables the service worker

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,14 @@ import * as ReactDOM from "react-dom";
 
 import Root from "./containers/Root";
 import "./index.css";
-import registerServiceWorker from "./registerServiceWorker";
+// import registerServiceWorker from "./registerServiceWorker";
 
 ReactDOM.render(<Root />, document.getElementById("root") as HTMLElement);
-registerServiceWorker();
+
+// Disable the service worker as it currently loads index.html from cache for
+// all unknown paths. This doesn't work well with our Ingress setup because if
+// you visit /kubeless/ you end up getting the Dashboard instead of the Kubeapps
+// UI. We can consider re-enabling this once the Kubeless UI is integrated in
+// the Dashboard and we no longer need the external link.
+
+// registerServiceWorker();


### PR DESCRIPTION
Disable the service worker as it currently loads index.html from cache for
all unknown paths. This doesn't work well with our Ingress setup because if
you visit /kubeless/ you end up getting the Dashboard instead of the Kubeapps
UI. We can consider re-enabling this once the Kubeless UI is integrated in
the Dashboard and we no longer need the external link.