### PR TITLE
fix: use non-specific date locale

### DIFF
--- a/src/components/ChartView/ChartVersionsList.tsx
+++ b/src/components/ChartView/ChartVersionsList.tsx
@@ -48,7 +48,7 @@ class ChartVersionsList extends React.Component<IChartVersionsListProps, IChartV
 
   public formatDate(dateStr: string) {
     const d = new Date(dateStr);
-    return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
   }
 
   public handleShowAll = () => {


### PR DESCRIPTION
according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString, locale is optional

fixes #93