### PR TITLE
use namespaced API endpoint for AppRepos

### DIFF
--- a/src/actions/repos.ts
+++ b/src/actions/repos.ts
@@ -47,9 +47,9 @@ const allActions = [
 ].map(getReturnOfExpression);
 export type AppReposAction = typeof allActions[number];
 
-export const deleteRepo = (name: string, namespace: string = "kubeapps") => {
+export const deleteRepo = (name: string) => {
   return async (dispatch: Dispatch<IStoreState>) => {
-    await AppRepository.delete(name, namespace);
+    await AppRepository.delete(name);
     dispatch(requestRepos());
     const repos = await AppRepository.list();
     dispatch(receiveRepos(repos.items));
@@ -57,12 +57,12 @@ export const deleteRepo = (name: string, namespace: string = "kubeapps") => {
   };
 };
 
-export const resyncRepo = (name: string, namespace: string = "kubeapps") => {
+export const resyncRepo = (name: string) => {
   return async (dispatch: Dispatch<IStoreState>) => {
-    const repo = await AppRepository.get(name, namespace);
+    const repo = await AppRepository.get(name);
     repo.spec.resyncRequests = repo.spec.resyncRequests || 0;
     repo.spec.resyncRequests++;
-    await AppRepository.update(name, namespace, repo);
+    await AppRepository.update(name, repo);
     // TODO: Do something to show progress
     dispatch(requestRepos());
     const repos = await AppRepository.list();
@@ -80,10 +80,10 @@ export const fetchRepos = () => {
   };
 };
 
-export const installRepo = (name: string, url: string, namespace: string) => {
+export const installRepo = (name: string, url: string) => {
   return async (dispatch: Dispatch<IStoreState>) => {
     dispatch(addRepo());
-    const added = await AppRepository.create(name, url, namespace);
+    const added = await AppRepository.create(name, url);
     dispatch(addedRepo(added));
     return added;
   };

--- a/src/containers/RepoListContainer.ts
+++ b/src/containers/RepoListContainer.ts
@@ -13,17 +13,17 @@ function mapStateToProps({ repos }: IStoreState) {
 
 function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
   return {
-    deleteRepo: async (name: string, namespace: string = "kubeapps") => {
-      return dispatch(actions.repos.deleteRepo(name, namespace));
+    deleteRepo: async (name: string) => {
+      return dispatch(actions.repos.deleteRepo(name));
     },
     fetchRepos: async () => {
       return dispatch(actions.repos.fetchRepos());
     },
-    install: async (name: string, url: string, namespace: string = "kubeapps") => {
-      return dispatch(actions.repos.installRepo(name, url, namespace));
+    install: async (name: string, url: string) => {
+      return dispatch(actions.repos.installRepo(name, url));
     },
-    resyncRepo: async (name: string, namespace: string = "kubeapps") => {
-      return dispatch(actions.repos.resyncRepo(name, namespace));
+    resyncRepo: async (name: string) => {
+      return dispatch(actions.repos.resyncRepo(name));
     },
   };
 }

--- a/src/shared/AppRepository.ts
+++ b/src/shared/AppRepository.ts
@@ -4,46 +4,39 @@ import { IAppRepository, IAppRepositoryList } from "./types";
 
 export class AppRepository {
   public static async list() {
-    const { data } = await axios.get<IAppRepositoryList>(
-      `${AppRepository.APIEndpoint}/apprepositories`,
-    );
+    const { data } = await axios.get<IAppRepositoryList>(AppRepository.APIEndpoint);
     return data;
   }
 
-  public static async get(name: string, namespace: string = "default") {
-    const { data } = await axios.get(AppRepository.getSelfLink(name, namespace));
+  public static async get(name: string) {
+    const { data } = await axios.get(AppRepository.getSelfLink(name));
     return data;
   }
 
-  public static async update(name: string, namespace: string = "default", newApp: IAppRepository) {
-    const { data } = await axios.put(AppRepository.getSelfLink(name, namespace), newApp);
+  public static async update(name: string, newApp: IAppRepository) {
+    const { data } = await axios.put(AppRepository.getSelfLink(name), newApp);
     return data;
   }
 
-  public static async delete(name: string, namespace: string = "default") {
-    const { data } = await axios.delete(AppRepository.getSelfLink(name, namespace));
+  public static async delete(name: string) {
+    const { data } = await axios.delete(AppRepository.getSelfLink(name));
     return data;
   }
 
-  public static async create(name: string, url: string, namespace: string = "default") {
-    const { data } = await axios.post<IAppRepository>(
-      `${AppRepository.APIEndpoint}/namespaces/${namespace}/apprepositories`,
-      {
-        apiVersion: "kubeapps.com/v1alpha1",
-        kind: "AppRepository",
-        metadata: {
-          name,
-          namespace,
-        },
-        spec: { type: "helm", url },
+  public static async create(name: string, url: string) {
+    const { data } = await axios.post<IAppRepository>(AppRepository.APIEndpoint, {
+      apiVersion: "kubeapps.com/v1alpha1",
+      kind: "AppRepository",
+      metadata: {
+        name,
       },
-    );
+      spec: { type: "helm", url },
+    });
     return data;
   }
 
-  // private static serviceCatalogURL: string = "https://svc-catalog-charts.storage.googleapis.com";
-  private static APIEndpoint: string = "/api/kube/apis/kubeapps.com/v1alpha1";
-  private static getSelfLink(name: string, namespace: string = "default"): string {
-    return `${AppRepository.APIEndpoint}/namespaces/${namespace}/apprepositories/${name}`;
+  private static APIEndpoint: string = "/api/kube/apis/kubeapps.com/v1alpha1/namespaces/kubeapps/apprepositories";
+  private static getSelfLink(name: string): string {
+    return `${AppRepository.APIEndpoint}/${name}`;
   }
 }

--- a/src/shared/ServiceCatalog.ts
+++ b/src/shared/ServiceCatalog.ts
@@ -1,30 +1,11 @@
 import axios from "axios";
 
 import * as urls from "../shared/url";
-import { AppRepository } from "./AppRepository";
 import { IClusterServiceClass } from "./ClusterServiceClass";
 import { IServiceInstance } from "./ServiceInstance";
-import { IAppRepository, IK8sList, IStatus } from "./types";
+import { IK8sList, IStatus } from "./types";
 
 export class ServiceCatalog {
-  public static async getCatalogRepo(): Promise<IAppRepository | undefined> {
-    const repos = await AppRepository.list();
-    const svcRepo = repos.items.find(repo => {
-      return !!(
-        repo.spec &&
-        repo.spec.url &&
-        repo.spec.url === "https://svc-catalog-charts.storage.googleapis.com"
-      );
-    });
-
-    return svcRepo;
-  }
-
-  public static async installCatalog(name: string, namespace: string) {
-    const url = "https://svc-catalog-charts.storage.googleapis.com";
-    await AppRepository.create(name, url, namespace);
-  }
-
   public static async getServiceClasses() {
     return this.getItems<IClusterServiceClass>("clusterserviceclasses");
   }


### PR DESCRIPTION
The Dashboard doesn't need cluster-level access to AppRepositories, so this ensures we only have access to AppRepositories within the kubeapps namespace.