### PR TITLE
Refresh Catalog After Service Provision

### DIFF
--- a/src/components/InstanceListView/InstanceCardList.tsx
+++ b/src/components/InstanceListView/InstanceCardList.tsx
@@ -22,7 +22,9 @@ export const InstanceCardList = (props: InstanceCardListProps) => {
               const status = conditions.shift(); // first in list is most recent
               const message = status ? status.message : "";
               const svcClass = classes.find(
-                potential => potential.metadata.name === instance.spec.clusterServiceClassRef.name,
+                potential =>
+                  !!instance.spec.clusterServiceClassRef &&
+                  potential.metadata.name === instance.spec.clusterServiceClassRef.name,
               );
               const broker = svcClass && svcClass.spec.clusterServiceBrokerName;
               const icon =

--- a/src/containers/ClassView.ts
+++ b/src/containers/ClassView.ts
@@ -39,7 +39,10 @@ function mapDispatchToProps(dispatch: Dispatch<IStoreState>) {
       planName: string,
       parameters: {},
     ) => {
-      dispatch(actions.catalog.provision(instanceName, namespace, className, planName, parameters));
+      await dispatch(
+        actions.catalog.provision(instanceName, namespace, className, planName, parameters),
+      );
+      return dispatch(actions.catalog.getCatalog());
     },
     push: (location: string) => dispatch(push(location)),
   };

--- a/src/containers/InstanceView.tsx
+++ b/src/containers/InstanceView.tsx
@@ -22,10 +22,18 @@ function mapStateToProps({ catalog }: IStoreState, { match: { params } }: IRoute
     i => i.metadata.name === params.instanceName && i.metadata.namespace === params.namespace,
   );
   const svcClass = instance
-    ? catalog.classes.find(c => c.metadata.name === instance.spec.clusterServiceClassRef.name)
+    ? catalog.classes.find(
+        c =>
+          !!instance.spec.clusterServiceClassRef &&
+          c.metadata.name === instance.spec.clusterServiceClassRef.name,
+      )
     : undefined;
   const svcPlan = instance
-    ? catalog.plans.find(p => p.metadata.name === instance.spec.clusterServicePlanRef.name)
+    ? catalog.plans.find(
+        p =>
+          !!instance.spec.clusterServicePlanRef &&
+          p.metadata.name === instance.spec.clusterServicePlanRef.name,
+      )
     : undefined;
 
   return {

--- a/src/shared/ServiceInstance.ts
+++ b/src/shared/ServiceInstance.ts
@@ -17,10 +17,10 @@ export interface IServiceInstance {
     clusterServiceClassExternalName: string;
     clusterServicePlanExternalName: string;
     externalID: string;
-    clusterServicePlanRef: {
+    clusterServicePlanRef?: {
       name: string;
     };
-    clusterServiceClassRef: {
+    clusterServiceClassRef?: {
       name: string;
     };
   };


### PR DESCRIPTION
- Added a catalog catalog refresh call once a new service has been provisioned.
- Fixed a typings bug where `clusterServicePlanRef` in `ServiceInstance` is always there; it may not exist immediately after creation.

fixes: https://github.com/kubeapps/dashboard/issues/94